### PR TITLE
Update condastats to 0.4.2

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "condastats" %}
-{% set version = "0.2.1" %}
+{% set version = "0.4.2" %}
 
 
 package:
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/condastats-{{ version }}.tar.gz
-  sha256: 013dfb759b78fc7088411cdf55e015cda25888efee0e21b57c946a7c9d4afb36
+  sha256: c0ffc117851000d7e4dae9ad611d4cc8a1d3f6e4c0479aa66340e014209c0b1f
 
 build:
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - condastats=condastats.cli:main
@@ -21,14 +21,16 @@ requirements:
   host:
     - pip
     - python {{ python_min }}
+    - setuptools >=61.0
+    - setuptools-scm >=6.2
   run:
-    - dask
-    - pyarrow
-    - fsspec >=2021.4.0
-    - numpy >=1.16.5
+    - dask >=2024.5.2
+    - numpy >=1.20.0
+    - pandas >=2.0.0
+    - pyarrow >=10.0.0
     - python >={{ python_min }}
-    - python-snappy
-    - s3fs >=2021.4.0
+    - python-snappy >=0.6.1
+    - s3fs >=2023.1.0
 
 test:
   imports:
@@ -41,14 +43,15 @@ test:
     - python {{ python_min }}
 
 about:
-  home: https://github.com/sophiamyang/condastats
+  home: https://github.com/conda-incubator/condastats
   summary: Conda package stats CLI
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  doc_url: condastats.readthedocs.io
+  doc_url: https://condastats.readthedocs.io
 
 extra:
   recipe-maintainers:
     - sophiamyang
     - seibert
+    - jezdez


### PR DESCRIPTION
## Summary

- Bump condastats from 0.2.1 to 0.4.2
- Update dependencies to match upstream `pyproject.toml` (add `pandas`, remove `fsspec`, update version pins)
- Add `setuptools` and `setuptools-scm` to host requirements (new build system)
- Bump `python_min` from 3.9 to 3.10
- Update homepage URL to `conda-incubator/condastats`
- Fix `doc_url` to include `https://` prefix
- Add `jezdez` to recipe maintainers

## Upstream release

https://github.com/conda-incubator/condastats/releases/tag/0.4.2